### PR TITLE
Reworks main window title to look "Program.bas:CurrentSubFunc"

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -9526,7 +9526,6 @@ SUB ideASCIIbox
 'IF INSTR(_OS$, "WIN") THEN ret% = SHELL("internal\ASCII-Picker.exe") ELSE ret% = SHELL("internal/ASCII-Picker")
 
 w = _WIDTH: h = _HEIGHT
-font = _FONT
 temp = _NEWIMAGE(640, 480, 32)
 temp1 = _NEWIMAGE(640, 480, 32)
 ws = _NEWIMAGE(640, 480, 32)
@@ -9601,7 +9600,7 @@ DO
         CASE 13: EXIT DO
         CASE 27
             _AUTODISPLAY
-            SCREEN 0: WIDTH w, h: _FONT font: _DEST 0: _DELAY .2
+            SCREEN 0: WIDTH w, h: _DEST 0: _DELAY .2
             IF _RESIZE THEN donothing = atall
             EXIT SUB
         CASE 32: toggle = NOT toggle
@@ -9619,13 +9618,13 @@ DO
     Ex = _EXIT
     IF Ex THEN
         _AUTODISPLAY
-        SCREEN 0: WIDTH w, h: _FONT font: _DEST 0: _DELAY .2
+        SCREEN 0: WIDTH w, h: _DEST 0: _DELAY .2
         IF _RESIZE THEN donothing = atall
         EXIT FUNCTION
     END IF
     IF MouseExit THEN
         _AUTODISPLAY
-        SCREEN 0: WIDTH w, h: _FONT font: _DEST 0: _DELAY .2
+        SCREEN 0: WIDTH w, h: _DEST 0: _DELAY .2
         IF _RESIZE THEN donothing = atall
         EXIT FUNCTION
     END IF
@@ -9648,9 +9647,7 @@ END IF
 
 _AUTODISPLAY
 
-SCREEN 0: WIDTH w, h
-_FONT font
-_DEST 0: _DELAY .2
+SCREEN 0: WIDTH w, h: _DEST 0: _DELAY .2
 IF _RESIZE THEN donothing = atall
 
 END FUNCTION

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -691,6 +691,19 @@ DO
                 ELSE
                     sfname$ = thisline$
                 END IF
+
+                'But what if we're past the end of this module's SUBs and FUNCTIONs,
+                'and all that's left is a bunch of comments or $INCLUDES?
+                'We'll also check for that:
+                for endSF_CHECK = idecy to iden
+                    thisline$ = idegetline(endSF_CHECK)
+                    thisline$ = LTRIM$(RTRIM$(thisline$))
+                    endedSF = 0
+                    ncthisline$ = UCASE$(thisline$)
+                    IF LEFT$(ncthisline$, 7) = "END SUB" THEN endedSF = 1: EXIT FOR
+                    IF LEFT$(ncthisline$, 12) = "END FUNCTION" THEN endedSF = 2: EXIT FOR
+                next
+                if endedSF = 0 then sfname$ = ""
                 EXIT FOR
             END IF
         NEXT


### PR DESCRIPTION
A quick current SUB/FUNCTION check was added to complement the program title with a colon and said SUB/FUNCTION name, exactly like it was done in QB4.5, for quick reference. Doesn't add a burden to the overall performance since FUNCTION ide2 already updates the main window title every main LOOP anyway.