### PR TITLE
Moves the search field to the status bar; adds visual indication (*) for external subs; improves on help.

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -692,6 +692,19 @@ DO
                     sfname$ = thisline$
                 END IF
 
+                'It could be that SUB or FUNCTION is inside a DECLARE LIBRARY.
+                'In such case, it must be ignored:
+                for declib_CHECK = currSF_CHECK to iden
+                    thisline$ = idegetline(declib_CHECK)
+                    thisline$ = LTRIM$(RTRIM$(thisline$))
+                    DeclaringLibrary = 0
+                    ncthisline$ = UCASE$(thisline$)
+                    IF LEFT$(ncthisline$, 11) = "END DECLARE" THEN DeclaringLibrary = -1: EXIT FOR
+                next
+                if DeclaringLibrary = -1 then sfname$ = ""
+                EXIT FOR
+
+                'Ok, we're not inside a DECLARE LIBRARY.
                 'But what if we're past the end of this module's SUBs and FUNCTIONs,
                 'and all that's left is a bunch of comments or $INCLUDES?
                 'We'll also check for that:

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -701,8 +701,7 @@ DO
                     ncthisline$ = UCASE$(thisline$)
                     IF LEFT$(ncthisline$, 11) = "END DECLARE" THEN DeclaringLibrary = -1: EXIT FOR
                 next
-                if DeclaringLibrary = -1 then sfname$ = ""
-                EXIT FOR
+                if DeclaringLibrary = -1 then sfname$ = "": EXIT FOR
 
                 'Ok, we're not inside a DECLARE LIBRARY.
                 'But what if we're past the end of this module's SUBs and FUNCTIONs,
@@ -6452,7 +6451,11 @@ IF x <= LEN(a$) THEN
         a2$ = CHR$(ASC(a$, x))
     END IF
     a2$ = UCASE$(a2$) 'a2$ now holds the word or character at current cursor position
-    if not alphanumeric(asc(right$(a2$, 1))) then a2$ = left$(a2$, len(a2$) - 1)  'removes sigil, if any
+    if len(a2$) > 1 then
+        do until alphanumeric(asc(right$(a2$, 1)))
+            a2$ = left$(a2$, len(a2$) - 1)  'removes sigil, if any
+        loop
+    end if
 END IF
 
 '-------- init --------
@@ -6504,7 +6507,11 @@ FOR y = 1 TO iden
         'If the user currently has the cursor over a SUB/FUNC name, let's highlight it
         'instead of the currently in edition, for a quick link functionality:
         n2$ = n$
-        if not alphanumeric(asc(right$(n$, 1))) then n2$ = left$(n$, len(n$) - 1)  'removes sigil, if any
+        if len(n2$) > 1 then
+            do until alphanumeric(asc(right$(n2$, 1)))
+                n2$ = left$(n$, len(n2$) - 1)  'removes sigil, if any
+            loop
+        end if
         IF a2$ = UCASE$(n2$) THEN PreferCurrentCursorSUBFUNC = (LEN(ly$) / 4)
 
         'attempt to cleanse n$, just in case there are any comments or other unwanted stuff

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -6439,6 +6439,7 @@ IF x <= LEN(a$) THEN
         a2$ = CHR$(ASC(a$, x))
     END IF
     a2$ = UCASE$(a2$) 'a2$ now holds the word or character at current cursor position
+    if not alphanumeric(asc(right$(a2$, 1))) then a2$ = left$(a2$, len(a2$) - 1)  'removes sigil, if any
 END IF
 
 '-------- init --------
@@ -6485,7 +6486,9 @@ FOR y = 1 TO iden
 
         'If the user currently has the cursor over a SUB/FUNC name, let's highlight it
         'instead of the currently in edition, for a quick link functionality:
-        IF a2$ = UCASE$(n$) THEN PreferCurrentCursorSUBFUNC = (LEN(ly$) / 4)
+        n2$ = n$
+        if not alphanumeric(asc(right$(n$, 1))) then n2$ = left$(n$, len(n$) - 1)  'removes sigil, if any
+        IF a2$ = UCASE$(n2$) THEN PreferCurrentCursorSUBFUNC = (LEN(ly$) / 4)
 
         'attempt to cleanse n$, just in case there are any comments or other unwanted stuff
         for CleanseN = 1 to len(n$)

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -727,7 +727,7 @@ DO
         COLOR 1, 7: LOCATE 2, ((idewx / 2) - 1) - (LEN(a$) - 1) \ 2: PRINT a$;
 
         'update search bar
-        LOCATE 2, idewx - 30
+        LOCATE idewy - 4, idewx - 30
         COLOR 7, 1: PRINT chr$(180);
         COLOR 3, 1: PRINT "Find[                     " + chr$(18) + "]";
         COLOR 7, 1: PRINT chr$(195);
@@ -735,7 +735,7 @@ DO
         IF LEN(f$) > 20 THEN
             f$ = string$(3, 250) + RIGHT$(f$, 17)
         END IF
-        LOCATE 2, idewx - 28 + 4: COLOR 3, 1: PRINT f$
+        LOCATE idewy - 4, idewx - 28 + 4: COLOR 3, 1: PRINT f$
         findtext$ = f$
 
         'alter cursor style to match insert mode
@@ -848,7 +848,7 @@ DO
 
         IF IdeSystem = 2 THEN 'override cursor position
             SCREEN , , 0, 0
-            LOCATE 2, idewx - 28 + 4 + LEN(findtext$)
+            LOCATE idewy - 4, idewx - 28 + 4 + LEN(findtext$)
             SCREEN , , 3, 0
         END IF
 
@@ -1424,8 +1424,8 @@ DO
 
     'IdeSystem specific code goes here
 
-    IF mCLICK THEN
-        IF mY = 2 AND mX > idewx - 30 AND mX < idewx - 1 THEN 'inside text box
+    IF mCLICK THEN 'Find [...] search field
+        IF mY = idewy - 4 AND mX > idewx - 30 AND mX < idewx - 1 THEN 'inside text box
             IF mX <= idewx - 28 + 2 THEN
                 IF LEN(idefindtext) = 0 THEN
                     IdeSystem = 2 'no search string, so begin editing
@@ -9222,14 +9222,14 @@ CLOSE #fh
 
 '72,19
 
-h = idewy + idesubwindow - 6
+h = idewy + idesubwindow - 9
 IF ln < h THEN h = ln
 IF h < 3 THEN h = 3
 
 i = 0
 idepar p, 20, h, ""
 p.x = idewx - 24
-p.y = 3
+p.y = idewy - 6 - h
 
 i = i + 1
 o(i).typ = 2

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -2005,6 +2005,7 @@ DO
                 IF lnks > 1 THEN
                     'clarify context
                     lnk$ = idef1box$(lnks$, lnks)
+                    if lnk$ = "C" then goto ideloop
                 END IF
 
 
@@ -2059,12 +2060,12 @@ DO
                     WikiParse a$
                     idehelp = 1
                     skipdisplay = 0
-                    IdeSystem = 1 '***
+                    IdeSystem = 3 'Standard qb45 behaviour. Allows for quick peek at help then ESC.
                     retval = 1: GOTO redraweverything2
                 END IF
 
                 WikiParse a$
-                IdeSystem = 1 '***
+                IdeSystem = 3 'Standard qb45 behaviour. Allows for quick peek at help then ESC.
                 GOTO specialchar
 
             END IF 'lnks
@@ -9898,6 +9899,9 @@ DO 'main loop
     IF K$ = CHR$(13) OR (focus = 2 AND info <> 0) OR (info = 1 AND focus = 1) THEN
         f$ = idetxt(o(1).stx)
         idef1box$ = f$
+        EXIT FUNCTION
+    ELSEIF K$ = CHR$(27) THEN
+        idef1box$ = "C"
         EXIT FUNCTION
     END IF
 

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -6460,6 +6460,8 @@ END IF
 ly$ = MKL$(1)
 CurrentlyViewingWhichSUBFUNC = 1
 PreferCurrentCursorSUBFUNC = 0
+InsideDECLARE = 0
+FoundExternalSUBFUNC = 0
 l$ = ideprogname$
 IF l$ = "" THEN l$ = "Untitled" + tempfolderindexstr$
 FOR y = 1 TO iden
@@ -6467,6 +6469,8 @@ FOR y = 1 TO iden
     a$ = LTRIM$(RTRIM$(a$))
     sf = 0
     nca$ = UCASE$(a$)
+    IF LEFT$(nca$, 8) = "DECLARE " and INSTR(nca$, " LIBRARY") > 0 THEN InsideDECLARE = -1
+    IF LEFT$(nca$, 11) = "END DECLARE" THEN InsideDECLARE = 0
     IF LEFT$(nca$, 4) = "SUB " THEN sf = 1: sf$ = "SUB  "
     IF LEFT$(nca$, 9) = "FUNCTION " THEN sf = 2: sf$ = "FUNC "
     IF sf THEN
@@ -6477,7 +6481,7 @@ FOR y = 1 TO iden
 
         'Check if the cursor is currently inside this SUB/FUNCTION to position the
         'selection properly in the list.
-        IF idecy >= y THEN
+        IF idecy >= y AND NOT InsideDECLARE THEN
             CurrentlyViewingWhichSUBFUNC = (LEN(ly$) / 4)
         END IF
         'End of current SUB/FUNCTION check
@@ -6511,6 +6515,8 @@ FOR y = 1 TO iden
                     exit for
             end select
         next
+
+        IF InsideDECLARE = -1 THEN n$ = "*" + n$: FoundExternalSUBFUNC = -1
 
         IF LEN(n$) <= 20 THEN
             n$ = n$ + SPACE$(20 - LEN(n$))
@@ -6583,6 +6589,9 @@ DO 'main loop
     '-------- end of generic display dialog box & objects --------
 
     '-------- custom display changes --------
+    IF FoundExternalSUBFUNC = -1 THEN
+        COLOR 8, 7: LOCATE p.h + 3, p.x + 2: PRINT "* external";
+    END IF
     '-------- end of custom display changes --------
 
     'update visual page and cursor position
@@ -7061,7 +7070,7 @@ IF t = 2 THEN 'list box
                 validCHARS$ = ""
                 FOR ai = 1 TO LEN(ListBoxITEMS(FindMatch))
                     aa = ASC(ucase$(ListBoxITEMS(findMatch)), ai)
-                    IF aa > 126 OR (k <> 95 AND aa = 95) THEN
+                    IF aa > 126 OR (k <> 95 AND aa = 95) OR (k <> 42 AND aa = 42) THEN
                         'ignore
                     ELSE
                         validCHARS$ = validCHARS$ + CHR$(aa)


### PR DESCRIPTION
- The quick search field is now positioned in the status area, on the same line as you can read "Status", so that it doesn't interfere with the program title.
- SUBs dialog now indicates (with *) that a procedure is external.
- Cursor is positioned inside the help window after F1, so it can be easily closed with ESC; also allows ESC to close the F1 dialog that appears when there is more than one topic with the selected keyword.