### PR TITLE
Correct parsing of OpenGL commands and addition of Multi-sample

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -27364,8 +27364,7 @@ QB64_GAMEPAD_INIT();
 
 #endif 
     
-	glutSetOption(GLUT_MULTISAMPLE, 8); //for anti-aliasing (Only available via direct OpenGL rendering)
-    glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH | GLUT_MULTISAMPLE);
+    glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH);
 
     glutInitWindowSize(640,400);//cannot be changed unless display_x(etc) are modified
 

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -27363,8 +27363,9 @@ QB64_GAMEPAD_INIT();
          */
 
 #endif 
-          
-    glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH);
+    
+	glutSetOption(GLUT_MULTISAMPLE, 8); //for anti-aliasing (Only available via direct OpenGL rendering)
+    glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH | GLUT_MULTISAMPLE);
 
     glutInitWindowSize(640,400);//cannot be changed unless display_x(etc) are modified
 

--- a/internal/c/parts/core/gl_header_for_parsing/gl.h
+++ b/internal/c/parts/core/gl_header_for_parsing/gl.h
@@ -1036,6 +1036,9 @@ typedef void (APIENTRY *PFNGLGETCOLORTABLEEXTPROC)(GLenum target,GLenum format,G
 typedef void (APIENTRY *PFNGLGETCOLORTABLEPARAMETERIVEXTPROC)(GLenum target,GLenum pname,GLint *params);
 typedef void (APIENTRY *PFNGLGETCOLORTABLEPARAMETERFVEXTPROC)(GLenum target,GLenum pname,GLfloat *params);
 
+// define constant for Multi-Sampling to work with OpenGL.
+#define GL_MULTISAMPLE 0x809D
+
 #ifdef __cplusplus
 }
 #endif

--- a/internal/c/parts/core/gl_header_for_parsing/gl.h
+++ b/internal/c/parts/core/gl_header_for_parsing/gl.h
@@ -1036,8 +1036,6 @@ typedef void (APIENTRY *PFNGLGETCOLORTABLEEXTPROC)(GLenum target,GLenum format,G
 typedef void (APIENTRY *PFNGLGETCOLORTABLEPARAMETERIVEXTPROC)(GLenum target,GLenum pname,GLint *params);
 typedef void (APIENTRY *PFNGLGETCOLORTABLEPARAMETERFVEXTPROC)(GLenum target,GLenum pname,GLfloat *params);
 
-// define constant for Multi-Sampling to work with OpenGL.
-#define GL_MULTISAMPLE 0x809D
 
 #ifdef __cplusplus
 }

--- a/source/subs_functions/extensions/opengl/opengl_global.bas
+++ b/source/subs_functions/extensions/opengl/opengl_global.bas
@@ -12,4 +12,4 @@ DIM SHARED GL_COMMANDS_LAST
 REDIM SHARED GL_DEFINES(2000) AS STRING 'average ~600 entries
 REDIM SHARED GL_DEFINES_VALUE(2000) AS _INTEGER64
 DIM SHARED GL_DEFINES_LAST
-DIM SHARED GL_KIT: GL_KIT = 0
+DIM SHARED GL_KIT: GL_KIT = 1 'making this true, will also rewrite gl_kit.bas parsing file along with gl_helper_code.h

--- a/source/subs_functions/extensions/opengl/opengl_methods.bas
+++ b/source/subs_functions/extensions/opengl/opengl_methods.bas
@@ -32,7 +32,7 @@ IF a$ = "GLdouble" THEN b$ = "DOUBLE": symbol$ = "#": typ = DOUBLETYPE - ISPOINT
 IF a$ = "GLclampd" THEN b$ = "DOUBLE": symbol$ = "#": typ = DOUBLETYPE - ISPOINTER: ctyp$ = "double"
 
 'void
-IF a$ = "GLvoid" THEN b$ = "_OFFSET": symbol$ = "&&": typ = OFFSETTYPE - ISPOINTER: ctyp$ = "ptrszint"
+IF a$ = "GLvoid" THEN b$ = "_OFFSET": symbol$ = "%&": typ = OFFSETTYPE - ISPOINTER: ctyp$ = "ptrszint"
 
 'typedef unsigned int GLenum;
 'typedef unsigned char GLboolean;


### PR DESCRIPTION
Hi! I have fixed the **mistype in GL parsing code** and also **added Multi-sample** which will work only with GL commands. I tested this on Windows 10 and on Windows XP. On XP, the multisampling doesn't work, because XP is a bit old. However, it renders stuffs without anti-aliasing without any errors.
Please test the Multi-sample from the code below on other OS.

```vb
SCREEN _NEWIMAGE(500, 500, 32)
DO
    _LIMIT 30
LOOP

SUB _GL () STATIC
    IF NOT glInit THEN _glViewport 0, 0, _WIDTH, _HEIGHT: glInit = -1

    _glEnable _GL_MULTISAMPLE
    _glBegin _GL_LINE_LOOP
    FOR i = 0 TO _PI(2) STEP .05
        _glVertex2f COS(i) * .7, SIN(i) * .7
    NEXT
    _glEnd
END SUB
```