### PR TITLE
Typo in wiki_methods.bas

### DIFF
--- a/source/ide/wiki/wiki_methods.bas
+++ b/source/ide/wiki/wiki_methods.bas
@@ -470,7 +470,7 @@ DO WHILE i <= n
             cb = 0
 
             IF cb$ = "PageSyntax" THEN Help_AddTxt "Syntax:" + CHR$(13), Help_Col_Section, 0
-            IF cb$ = "PageDescription" THEN Help_AddTxt "Descripton:" + CHR$(13), Help_Col_Section, 0
+            IF cb$ = "PageDescription" THEN Help_AddTxt "Description:" + CHR$(13), Help_Col_Section, 0
             IF cb$ = "PageExamples" THEN Help_AddTxt "Code Examples:" + CHR$(13), Help_Col_Section, 0
             IF cb$ = "PageSeeAlso" THEN Help_AddTxt "See also:" + CHR$(13), Help_Col_Section, 0
 


### PR DESCRIPTION
Hi, here is a trivial fix for a typo in wiki_methods.bas