### PR TITLE
Fixed a typo in opengl_methods.bas

### DIFF
--- a/source/subs_functions/extensions/opengl/opengl_methods.bas
+++ b/source/subs_functions/extensions/opengl/opengl_methods.bas
@@ -32,7 +32,7 @@ IF a$ = "GLdouble" THEN b$ = "DOUBLE": symbol$ = "#": typ = DOUBLETYPE - ISPOINT
 IF a$ = "GLclampd" THEN b$ = "DOUBLE": symbol$ = "#": typ = DOUBLETYPE - ISPOINTER: ctyp$ = "double"
 
 'void
-IF a$ = "GLvoid" THEN b$ = "_OFFSET": symbol$ = "&&": typ = OFFSETTYPE - ISPOINTER: ctyp$ = "ptrszint"
+IF a$ = "GLvoid" THEN b$ = "_OFFSET": symbol$ = "%&": typ = OFFSETTYPE - ISPOINTER: ctyp$ = "ptrszint"
 
 'typedef unsigned int GLenum;
 'typedef unsigned char GLboolean;


### PR DESCRIPTION
There is typo in opengl_methods.bas  as stated here - https://github.com/Galleondragon/qb64/issues/39
I've fixed that. :)