### PR TITLE
Separate source file for string manipulation functions

### DIFF
--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -25031,31 +25031,6 @@ Error_Happened = 1
 Error_Message = a$
 END SUB
 
-FUNCTION StrRemove$ (myString$, whatToRemove$) 'noncase sensitive
-a$ = myString$
-b$ = LCASE$(whatToRemove$)
-i = INSTR(LCASE$(a$), b$)
-DO WHILE i
-    a$ = LEFT$(a$, i - 1) + RIGHT$(a$, LEN(a$) - i - LEN(b$) + 1)
-    i = INSTR(LCASE$(a$), b$)
-LOOP
-StrRemove$ = a$
-END FUNCTION
-
-FUNCTION StrReplace$ (myString$, find$, replaceWith$) 'noncase sensitive
-IF LEN(myString$) = 0 THEN EXIT FUNCTION
-a$ = myString$
-b$ = LCASE$(find$)
-basei = 1
-i = INSTR(basei, LCASE$(a$), b$)
-DO WHILE i
-    a$ = LEFT$(a$, i - 1) + replaceWith$ + RIGHT$(a$, LEN(a$) - i - LEN(b$) + 1)
-    basei = i + LEN(replaceWith$)
-    i = INSTR(basei, LCASE$(a$), b$)
-LOOP
-StrReplace$ = a$
-END FUNCTION
-
 SUB WriteConfigSetting (heading$, item$, tvalue$)
 value$ = tvalue$
 SHARED ConfigFile$, ConfigBak$
@@ -25346,6 +25321,8 @@ v = VAL(t$)
 t1$ = LTRIM$(STR$(v))
 IF t$ = t1$ THEN VerifyNumber = -1
 END FUNCTION
+
+'$INCLUDE:'utilities\strings.bas'
 
 '$INCLUDE:'subs_functions\extensions\opengl\opengl_methods.bas'
 

--- a/source/utilities/strings.bas
+++ b/source/utilities/strings.bas
@@ -1,0 +1,28 @@
+'
+' String manipulation functions
+'
+
+FUNCTION StrRemove$ (myString$, whatToRemove$) 'noncase sensitive
+    a$ = myString$
+    b$ = LCASE$(whatToRemove$)
+    i = INSTR(LCASE$(a$), b$)
+    DO WHILE i
+        a$ = LEFT$(a$, i - 1) + RIGHT$(a$, LEN(a$) - i - LEN(b$) + 1)
+        i = INSTR(LCASE$(a$), b$)
+    LOOP
+    StrRemove$ = a$
+END FUNCTION
+
+FUNCTION StrReplace$ (myString$, find$, replaceWith$) 'noncase sensitive
+    IF LEN(myString$) = 0 THEN EXIT FUNCTION
+    a$ = myString$
+    b$ = LCASE$(find$)
+    basei = 1
+    i = INSTR(basei, LCASE$(a$), b$)
+    DO WHILE i
+        a$ = LEFT$(a$, i - 1) + replaceWith$ + RIGHT$(a$, LEN(a$) - i - LEN(b$) + 1)
+        basei = i + LEN(replaceWith$)
+        i = INSTR(basei, LCASE$(a$), b$)
+    LOOP
+    StrReplace$ = a$
+END FUNCTION


### PR DESCRIPTION
Since qb64.bas is quite huge I'd like to suggest moving some specific parts to separate source files. Here for example with the string manipulation functions.