### PR TITLE
Fixes #90

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -11217,7 +11217,8 @@ static bool clear_console(void)
 	    return false;
 	ret = (GetConsoleScreenBufferInfo(hConsole, &csbi) &&
 	    FillConsoleOutputCharacterA(console, ' ',
-	        csbi.dwSize.X * csbi.dwSize.Y, origin, &nCharsWritten));
+	        csbi.dwSize.X * csbi.dwSize.Y, origin, &nCharsWritten) &&
+	    SetConsoleCursorPosition(hConsole, origin));
 	CloseHandle(console);
 	return ret;
 }
@@ -11240,6 +11241,8 @@ static int putc_tty(int c)
 static bool clear_console(void)
 {
 	int err;
+	if (!isatty(fileno(stdout)))
+		return false;
 	ttyfd = open("/dev/tty", O_RDWR);
 	if (ttyfd == -1) {
 	    // No controlling TTY for the process?

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -22,6 +22,17 @@
     
 #endif
 
+#ifndef QB64_WINDOWS
+#include <curses.h>
+#include <term.h>
+// ncurses defines macros for terminfo capability names, which causes
+// conflicts.
+#undef create_window
+#undef buttons
+#undef tab
+#undef newline
+#endif
+
 
 int32 disableEvents=0;
 
@@ -11192,7 +11203,66 @@ void qbg_sub_view(int32 x1,int32 y1,int32 x2,int32 y2,int32 fillcolor,int32 bord
     return;
 }
 
-
+#ifdef QB64_WINDOWS
+static bool clear_console(void)
+{
+	bool ret;
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+	COORD origin = {0, 0};
+	HANDLE hConsole = CreateFileA("CONOUT$",
+	    GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE,
+	    NULL, OPEN_EXISTING, 0, NULL);
+	DWORD nCharsWritten;
+	if (hConsole == INVALID_HANDLE_VALUE)
+	    return false;
+	ret = (GetConsoleScreenBufferInfo(hConsole, &csbi) &&
+	    FillConsoleOutputCharacterA(console, ' ',
+	        csbi.dwSize.X * csbi.dwSize.Y, origin, &nCharsWritten));
+	CloseHandle(console);
+	return ret;
+}
+#else
+// Terminal file descriptor
+static int ttyfd;
+// putchar replacement acting on ttyfd instead of stdin
+static int putc_tty(int c)
+{
+	int nWritten = 0;
+	unsigned char uc = (unsigned char)c;
+	if (ttyfd == -1)
+		return EOF;
+	while (nWritten == 0)
+		nWritten = write(ttyfd, &uc, 1);
+	if (nWritten != 1)
+		return EOF;
+	return c;
+}
+static bool clear_console(void)
+{
+	int err;
+	ttyfd = open("/dev/tty", O_RDWR);
+	if (ttyfd == -1) {
+	    // No controlling TTY for the process?
+	    return false;
+	}
+	// A non-null err pointer must be passed to prevent the process from
+	// exiting.
+	if (ERR == setupterm(NULL, ttyfd, &err)) {
+	    // No matter what the error was, it is ignored, and we
+	    // simply return that there was an error.
+	    return false;
+	}
+	char *cls = tigetstr("clear");
+	if (cls == (char *)-1 || cls == (char *)0) {
+	    return false;
+	}
+	tputs(cls, 1, putc_tty);
+	del_curterm(cur_term);
+	close(ttyfd);
+	ttyfd = -1;
+	return true;
+}
+#endif
 
 void sub_cls(int32 method,uint32 use_color,int32 passed){
     if (new_error) return;
@@ -11232,7 +11302,10 @@ void sub_cls(int32 method,uint32 use_color,int32 passed){
     if ((passed&1)==0){//no method specified
         //video mode: clear only graphics viewport
         //text mode: clear text view port AND the bottom line
-        if (write_page->text){
+        if (write_page->console){
+            // TODO: handle background arguments
+            clear_console();
+        }else if (write_page->text){
             //text view port
             characters=write_page->width*(write_page->bottom_row-write_page->top_row+1);
             sp=(uint16*)&write_page->offset[(write_page->top_row-1)*write_page->width*2];
@@ -11275,7 +11348,10 @@ void sub_cls(int32 method,uint32 use_color,int32 passed){
     }
     
     if (method==0){//clear everything
-        if (write_page->text){
+        if (write_page->console){
+            // TODO: handle background arguments
+            clear_console();
+        }else if (write_page->text){
             characters=write_page->height*write_page->width;
             sp=(uint16*)write_page->offset;
             for (i=0;i<characters;i++){sp[i]=clearvalue;}
@@ -11304,7 +11380,10 @@ void sub_cls(int32 method,uint32 use_color,int32 passed){
     }
     
     if (method==1){//ONLY clear the graphics viewport
-        if (write_page->text) return;
+        if (write_page->console){
+            // TODO: handle background arguments
+            clear_console();
+        }else if (write_page->text) return;
         //graphics view port
         if (write_page->bytes_per_pixel==1){//8-bit
             if (write_page->clipping_or_scaling){
@@ -11335,7 +11414,12 @@ void sub_cls(int32 method,uint32 use_color,int32 passed){
     }
     
     if (method==2){//ONLY clear the VIEW PRINT range text viewport
-        if (write_page->text){
+        if (write_page->console){
+            // TODO: handle background arguments
+            // Once VIEW PRINT is supported in the console, this will need
+            // handled as well.
+            clear_console();
+        }else if (write_page->text){
             //text viewport
             characters=write_page->width*(write_page->bottom_row-write_page->top_row+1);
             sp=(uint16*)&write_page->offset[(write_page->top_row-1)*write_page->width*2];

--- a/internal/c/makeline_lnx.txt
+++ b/internal/c/makeline_lnx.txt
@@ -1,2 +1,2 @@
-g++ -w qbx.cpp parts/core/os/lnx/src.a -lGL -lGLU -lX11 -lpthread -ldl -lrt -D FREEGLUT_STATIC -o 
+g++ -w qbx.cpp parts/core/os/lnx/src.a -lGL -lGLU -lX11 -lcurses -lpthread -ldl -lrt -D FREEGLUT_STATIC -o 
 

--- a/internal/c/makeline_osx.txt
+++ b/internal/c/makeline_osx.txt
@@ -1,4 +1,4 @@
-g++ -w qbx.cpp  -framework OpenGL -framework IOKit -framework GLUT -framework OpenGL -framework Cocoa  -o 
+g++ -w qbx.cpp  -framework OpenGL -framework IOKit -framework GLUT -framework OpenGL -framework Cocoa -lcurses -o 
 
 (below for reference purposes only, above is minimum viable)
-g++ -w qbx.cpp -framework ApplicationServices -framework OpenGL -framework IOKit -framework CoreServices -framework CoreFoundation -framework GLUT -framework OpenGL -framework Cocoa  -o 
+g++ -w qbx.cpp -framework ApplicationServices -framework OpenGL -framework IOKit -framework CoreServices -framework CoreFoundation -framework GLUT -framework OpenGL -framework Cocoa -lcurses -o 

--- a/setup_lnx.sh
+++ b/setup_lnx.sh
@@ -105,7 +105,7 @@ if [ "$DISTRO" == "arch" ]; then
   if [ "$SDL" == "1" ]; then
     pkg_list="gcc sdl sdl_image sdl_mixer sdl_net sdl_ttf $GET_WGET"
   else
-    pkg_list="gcc $GET_WGET"
+    pkg_list="gcc ncurses $GET_WGET"
   fi
   installed_packages=`pacman -Q`
   installer_command="sudo pacman -S "
@@ -115,7 +115,7 @@ elif [ "$DISTRO" == "linuxmint" ] || [ "$DISTRO" == "ubuntu" ] || [ "$DISTRO" ==
   if [ "$SDL" == "1" ]; then
     pkg_list="g++ libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-net1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev $GET_WGET"
   else
-    pkg_list="g++ mesa-common-dev libglu1-mesa-dev libasound2-dev $GET_WGET"
+    pkg_list="g++ mesa-common-dev libglu1-mesa-dev libncurses-dev libasound2-dev $GET_WGET"
   fi
   installed_packages=`dpkg -l`
   installer_command="sudo apt-get -y install "
@@ -125,7 +125,7 @@ elif [ "$DISTRO" == "fedora" ] || [ "$DISTRO" == "redhat" ] || [ "$DISTRO" == "c
   if [ "$SDL" == "1" ]; then
     pkg_list="gcc-c++ SDL-devel SDL_image-devel SDL_mixer-devel SDL_net-devel SDL_ttf-devel $GET_WGET"
   else
-    pkg_list="gcc-c++ mesa-libGLU-devel alsa-lib-devel $GET_WGET"
+    pkg_list="gcc-c++ mesa-libGLU-devel ncurses-devel alsa-lib-devel $GET_WGET"
   fi
   installed_packages=`yum list installed`
   installer_command="sudo yum install "
@@ -192,7 +192,7 @@ else
   echo "Building 'QB64'"
   cp -r ./internal/source/* ./internal/temp/
   cd internal/c
-  g++ -w qbx.cpp libqb/os/lnx/libqb_setup.o parts/video/font/ttf/os/lnx/src.o parts/core/os/lnx/src.a -lGL -lGLU -lX11 -lpthread -ldl -lrt -D FREEGLUT_STATIC -o ../../qb64
+  g++ -w qbx.cpp libqb/os/lnx/libqb_setup.o parts/video/font/ttf/os/lnx/src.o parts/core/os/lnx/src.a -lGL -lGLU -lX11 -lcurses -lpthread -ldl -lrt -D FREEGLUT_STATIC -o ../../qb64
   cd ../..
 fi
 

--- a/setup_osx.command
+++ b/setup_osx.command
@@ -47,7 +47,7 @@ cd ../../../../../../../..
 echo "Building 'QB64' (~3 min)"
 cp ./internal/source/* ./internal/temp/
 cd internal/c
-g++ -w qbx.cpp libqb/os/osx/libqb_setup.o parts/video/font/ttf/os/osx/src.o -framework GLUT -framework OpenGL -framework Cocoa -o ../../qb64
+g++ -w qbx.cpp libqb/os/osx/libqb_setup.o parts/video/font/ttf/os/osx/src.o -framework GLUT -framework OpenGL -framework Cocoa -lcurses -o ../../qb64
 cd ../..
 
 echo ""


### PR DESCRIPTION
There's a new dependency on the system's curses library on non-Windows platforms, which I've added into the setup scripts.

For macOS/OS X, I just assumed that it's installed with the developer tools already since I'm somewhat unfamiliar with how things work on that platform. If that's not true, some more modifications will be needed to fix the issue (or, if a fix is not desirable, to otherwise limit the ability to interact with the console to Windows and Linux).

I'm not sure if this will affect Android at all or not since I don't use the Android port, assuming it's still maintained. AFAIK, Android doesn't really have a "console" or "terminal", so hopefully the new curses requirement doesn't affect things.