### PR TITLE
Fix X11 BadAtom errors that prevent IDE launch

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -22008,10 +22008,10 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
                     //SDL_EventState(SDL_SYSWMEVENT,SDL_ENABLE);
                     //SDL_SetEventFilter(x11filter);
                     x11_lock();
-                    targets=XInternAtom(X11_display,"TARGETS",True);
-                    utf8string=XInternAtom(X11_display,"UTF8_STRING",True);
-                    compoundtext=XInternAtom(X11_display,"COMPOUND_TEXT",True);
-                    clipboard=XInternAtom(X11_display,"CLIPBOARD",True);
+                    targets=XInternAtom(X11_display,"TARGETS",False);
+                    utf8string=XInternAtom(X11_display,"UTF8_STRING",False);
+                    compoundtext=XInternAtom(X11_display,"COMPOUND_TEXT",False);
+                    clipboard=XInternAtom(X11_display,"CLIPBOARD",False);
                     x11_unlock();
                 }
             }


### PR DESCRIPTION
The assumption by QB64 that the atoms referring to the CLIPBOARD selection and the CLIPBOARD, TARGETS, and UTF8_STRING selection targets already exist in the X server can cause the IDE to fail to launch.  The following shell session excerpt illustrates what happens:

```
~/qb64> echo $DISPLAY
:0
~/qb64> Xephyr :1 &
~/qb64> env DISPLAY=:1 ./qb64
X Error of failed request:  BadAtom (invalid Atom parameter)
  Major opcode of failed request:  23 (X_GetSelectionOwner)
  Atom id in failed request:  0x0
  Serial number of failed request:  ...
```

`XGetSelectionOwner(X11_display, clipboard)` is the only occurrence of the `XGetSelectionOwner` function; it is at libqb.cpp:22041 in the `x11clipboardpaste` function.  I'm uncertain why QB64 is trying to paste something on IDE startup, but it results in the IDE failing with an X error as shown above.

While the primary culprit is the CLIPBOARD selection atom, it's very likely that the other atoms are also not present if the CLIPBOARD selection atom is missing, so I assumed that was the case and requested that they be created if they're not already present.

The problem is also not just my use of Xephyr as my .xinitrc could contain only `xterm & exec twm` and execute `startx` from the Linux console, followed by `cd qb64 && ./qb64` inside the running xterm to get a similar result.