### PR TITLE
Ignores _WINDOWHASFOCUS for the IDE in Linux

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -1307,14 +1307,16 @@ FUNCTION ide2 (ignore)
             END IF
         END IF
 
-        IF _WINDOWHASFOCUS THEN
-            LOCATE , , 1
-            _PALETTECOLOR 5, IDEBracketHighlightColor, 0
-            _PALETTECOLOR 6, IDEBackgroundColor2, 0
-        ELSE
-            LOCATE , , 0
-            _PALETTECOLOR 5, IDEBackgroundColor, 0
-            _PALETTECOLOR 6, IDEBackgroundColor, 0
+        IF os$ = "WIN" OR MacOSX = 1 THEN
+            IF _WINDOWHASFOCUS THEN
+                LOCATE , , 1
+                _PALETTECOLOR 5, IDEBracketHighlightColor, 0
+                _PALETTECOLOR 6, IDEBackgroundColor2, 0
+            ELSE
+                LOCATE , , 0
+                _PALETTECOLOR 5, IDEBackgroundColor, 0
+                _PALETTECOLOR 6, IDEBackgroundColor, 0
+            END IF
         END IF
 
         IF KALT THEN 'alt held
@@ -1339,7 +1341,7 @@ FUNCTION ide2 (ignore)
                 idealthighlight = 0
                 LOCATE , , 0: COLOR 0, 7: LOCATE 1, 1: PRINT menubar$;
                 IF ideentermenu = 1 AND KCONTROL = 0 THEN 'alt was pressed then released
-                    IF _WINDOWHASFOCUS THEN
+                    IF _WINDOWHASFOCUS OR os$ = "LNX" THEN
                         LOCATE , , , IDENormalCursorStart, IDENormalCursorEnd
                         skipdisplay = 0
                         ideentermenu = 0
@@ -4032,7 +4034,7 @@ FUNCTION ide2 (ignore)
                 DO
                     _LIMIT 1000
                     GetInput
-                    IF _WINDOWHASFOCUS = 0 THEN
+                    IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
                         LOCATE 1, 1: COLOR 0, 7: PRINT menubar$;
                         SCREEN , , 3, 0: PCOPY 3, 0
                         GOTO ideloop
@@ -4045,7 +4047,7 @@ FUNCTION ide2 (ignore)
                 KB = KEY_ESC
             END IF
 
-            IF _WINDOWHASFOCUS = 0 THEN
+            IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
                 LOCATE 1, 1: COLOR 0, 7: PRINT menubar$;
                 SCREEN , , 3, 0: PCOPY 3, 0
                 GOTO ideloop
@@ -4253,7 +4255,7 @@ FUNCTION ide2 (ignore)
                 DO
                     _LIMIT 1000
                     GetInput
-                    IF _WINDOWHASFOCUS = 0 THEN
+                    IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
                         LOCATE 1, 1: COLOR 0, 7: PRINT menubar$;
                         PCOPY 3, 0: SCREEN , , 3, 0
                         GOTO ideloop
@@ -4267,7 +4269,7 @@ FUNCTION ide2 (ignore)
                 GOTO startmenu2
             END IF
             IF _EXIT THEN ideexit = 1: GOTO ideloop
-            IF _WINDOWHASFOCUS = 0 THEN
+            IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
                 LOCATE 1, 1: COLOR 0, 7: PRINT menubar$;
                 PCOPY 3, 0: SCREEN , , 3, 0
                 GOTO ideloop


### PR DESCRIPTION
Since implementation, the only feedback for this feature from Linux users was negative (@CodeHunter, I'm looking at you), so it's disabled in this version.